### PR TITLE
Require refinery/admin.js to fulfill dependency

### DIFF
--- a/app/assets/javascripts/refinery/wymeditor.js
+++ b/app/assets/javascripts/refinery/wymeditor.js
@@ -34,6 +34,7 @@
  *= require wymeditor/validators
  *= require_tree ../wymeditor/browsers
  *= require wymeditor/init_interface
+ *= require refinery/admin
  *= require refinery/boot_wym
  *= require_self
 */


### PR DESCRIPTION
A problem with moving the javascript to refinery/admin.js is that the boot_wym javascript is being loaded first. I'm not sure why that's so? Boot_wym.js needs the onOpenDialog and onCloseDialog routines.

Is this requiring refinery/admin here the right way to handle this issue? I _think_ so.
