### PR TITLE
Do not load refinery admin javascripts again.

### DIFF
--- a/app/assets/javascripts/refinery/wymeditor.js
+++ b/app/assets/javascripts/refinery/wymeditor.js
@@ -34,7 +34,6 @@
  *= require wymeditor/validators
  *= require_tree ../wymeditor/browsers
  *= require wymeditor/init_interface
- *= require refinery/admin
  *= require refinery/boot_wym
  *= require_self
 */


### PR DESCRIPTION
Refinery itself takes care of loading the admin javascripts including pagination.

Including this line results in it being included twice -- once by this manifest and once by refinerycms-core's refinery/application manifest.

Note that this change must be used in conjunction with moving the visual_editor_javascripts block on refinerycms-core to _after_ the refinery/application include tag. See refinery/refinerycms#2604
