### PR TITLE
Changed absolute asset paths to asset_path helper when loading editor assets

### DIFF
--- a/app/assets/javascripts/refinery/boot_wym.js.erb
+++ b/app/assets/javascripts/refinery/boot_wym.js.erb
@@ -229,9 +229,9 @@ WYMeditor.editor.prototype.loadIframe = function(iframe) {
     doc.close();
 
     var doc_head = doc.head || $(doc).find('head').get(0);
-    $("<link href='<%= Rails.application.config.assets.prefix + '/wymeditor/skins/refinery/wymiframe.css' %>' media='all' rel='stylesheet' />").appendTo(doc_head);
-    $("<link href='<%= Rails.application.config.assets.prefix + '/refinery/formatting.css' %>' media='all' rel='stylesheet' />").appendTo(doc_head);
-    $("<link href='<%= Rails.application.config.assets.prefix + '/refinery/theme.css' %>' media='all' rel='stylesheet' />").appendTo(doc_head);
+    $("<link href='<%= asset_path('wymeditor/skins/refinery/wymiframe.css') %>' media='all' rel='stylesheet' />").appendTo(doc_head);
+    $("<link href='<%= asset_path('refinery/formatting.css') %>' media='all' rel='stylesheet' />").appendTo(doc_head);
+    $("<link href='<%= asset_path('refinery/theme.css') %>' media='all' rel='stylesheet' />").appendTo(doc_head);
   }
   if ((id_of_editor = wym._element.parent().attr('id')) != null) {
     $(doc.body).addClass(id_of_editor);


### PR DESCRIPTION
I was having troubled with the absolute paths in production, due to asset compilation. Instead I am using the asset_path helper, which has fixed my issue.
