### PR TITLE
Remove executables from gemspec

### DIFF
--- a/refinerycms-wymeditor.gemspec
+++ b/refinerycms-wymeditor.gemspec
@@ -13,7 +13,6 @@ Gem::Specification.new do |s|
 
   s.files             = `git ls-files`.split("\n")
   s.test_files        = `git ls-files -- spec/*`.split("\n")
-  s.executables       = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
 
   s.add_dependency              'refinerycms-core',     '~> 3.0', '>= 3.0.0'
 end


### PR DESCRIPTION
The executables in the bin/ folder (rake and rails) should not be included in this gem.

As a result the 'global' binstub is over-written. This causes a conflict warning from bundler:

```
Bundler is using a binstub that was created for a different gem.
This is deprecated, in future versions you may need to `bundle binstub refinerycms-wymeditor` to work around a system/bundle conflict.
```
Fix for: https://github.com/parndt/refinerycms-wymeditor/issues/22

Also:
https://github.com/refinery/refinerycms/issues/2847#issuecomment-71273204
https://github.com/refinery/refinerycms/issues/2854