### PR TITLE
Add z-index on wym_classes

### DIFF
--- a/app/assets/stylesheets/wymeditor/skins/refinery/skin.css.scss
+++ b/app/assets/stylesheets/wymeditor/skins/refinery/skin.css.scss
@@ -476,6 +476,7 @@ a.wym_wymeditor_link {
   top: 23px;
   padding-top: 6px !important;
   width: 200px;
+  z-index: 1;
 }
 .wym_classes_hidden {
   display: none;


### PR DESCRIPTION
it fixes overlap content on big lists

Before
![wym-list-zindex-before](https://cloud.githubusercontent.com/assets/1678530/5981871/d64a3d1e-a88b-11e4-9e6a-c489d9563563.png)

After
![wym-list-zindex-after](https://cloud.githubusercontent.com/assets/1678530/5981872/daad0440-a88b-11e4-8e78-af74f6e687a3.png)

[ci skip]