### PR TITLE
Add config switch for paste dialogue.

### DIFF
--- a/app/assets/javascripts/wymeditor/prototypes.js.erb
+++ b/app/assets/javascripts/wymeditor/prototypes.js.erb
@@ -268,12 +268,14 @@ WYMeditor.editor.prototype.html = function(html) {
  * @description Catch the browser paste action and open the appropriate dialog instead
  */
 WYMeditor.editor.prototype.intercept_paste = function(e) {
+<% if Refinery::Wymeditor.config.intercept_paste %>
   var wym = WYMeditor.INSTANCES[this.title];
   wym.format_block();
   wym.exec(WYMeditor.PASTE);
   if (e) {
     e.preventDefault();
   }
+<% end %>
 };
 
 /* @name xhtml

--- a/config/initializers/refinery/wymeditor.rb.erb
+++ b/config/initializers/refinery/wymeditor.rb.erb
@@ -1,4 +1,0 @@
-Refinery::Wymeditor.configure do |config|
-  # Add extra tags to the wymeditor whitelist e.g. = {'a' => {'attributes': '1': 'href'}} or just {'a' => {}}
-  # config.whitelist_tags = <%= Refinery::Wymeditor.whitelist_tags.inspect %>
-end

--- a/lib/generators/refinery/wymeditor/templates/config/initializers/refinery/wymeditor.rb.erb
+++ b/lib/generators/refinery/wymeditor/templates/config/initializers/refinery/wymeditor.rb.erb
@@ -1,5 +1,11 @@
 # encoding: utf-8
 Refinery::Wymeditor.configure do |config|
-  # Add extra tags to the wymeditor whitelist e.g. = {'tag' => {'attributes' => {'1' => 'href'}}} or just {'tag' => {}}
+  # Add extra tags to the wymeditor whitelist e.g. = {'a' => {'attributes': '1': 'href'}} or just {'a' => {}}
   # config.whitelist_tags = <%= Refinery::Wymeditor.whitelist_tags.inspect %>
+
+  # Toggle the paste dialog when using browser paste.
+  # You will have to clear your asset cache after changing this setting.
+  # In development mode: this is as simple as: `rm -rf tmp/cache/assets`.
+  # In production mode: hopefully you recompile assets every time you deploy.
+  # config.intercept_paste = <%= Refinery::Wymeditor.intercept_paste.inspect %>
 end

--- a/lib/refinery/wymeditor/configuration.rb
+++ b/lib/refinery/wymeditor/configuration.rb
@@ -2,9 +2,10 @@ module Refinery
   module Wymeditor
     include ActiveSupport::Configurable
 
-    config_accessor :whitelist_tags
+    config_accessor :whitelist_tags, :intercept_paste
 
     self.whitelist_tags = {}
+    self.intercept_paste = true
 
   end
 end


### PR DESCRIPTION
This enables more advanced users to accept any HTML that comes long for the ride when pasting, such as links, formatting, headings, etc.