### PR TITLE
Remove empty line in xhtml parser result

### DIFF
--- a/app/assets/javascripts/wymeditor/classes.js.erb
+++ b/app/assets/javascripts/wymeditor/classes.js.erb
@@ -1177,7 +1177,8 @@ WYMeditor.XhtmlSaxListener.prototype.joinRepeatedEntities = function(xhtml)
 
 WYMeditor.XhtmlSaxListener.prototype.removeEmptyTags = function(xhtml)
 {
-  var emptyTags = '<('+this.block_tags.join("|").replace(/\|td/,'').replace(/\|th/, '')+')>(<br \/>|&#160;|&nbsp;|\\s)*<\/\\1>'
+  var tags = this.block_tags.join("|").replace(/\|td/,'').replace(/\|th/, '');
+  var emptyTags = '<(' + tags + ')>(<br \/>|&#160;|&nbsp;|\\s)*<\/\\1>';
   return xhtml.replace(new RegExp(emptyTags ,'g'),'').trim();
 };
 

--- a/app/assets/javascripts/wymeditor/classes.js.erb
+++ b/app/assets/javascripts/wymeditor/classes.js.erb
@@ -1177,7 +1177,8 @@ WYMeditor.XhtmlSaxListener.prototype.joinRepeatedEntities = function(xhtml)
 
 WYMeditor.XhtmlSaxListener.prototype.removeEmptyTags = function(xhtml)
 {
-  return xhtml.replace(new RegExp('<('+this.block_tags.join("|").replace(/\|td/,'').replace(/\|th/, '')+')>(<br \/>|&#160;|&nbsp;|\\s)*<\/\\1>' ,'g'),'');
+  var emptyTags = '<('+this.block_tags.join("|").replace(/\|td/,'').replace(/\|th/, '')+')>(<br \/>|&#160;|&nbsp;|\\s)*<\/\\1>'
+  return xhtml.replace(new RegExp(emptyTags ,'g'),'').trim();
 };
 
 WYMeditor.XhtmlSaxListener.prototype.removeBrInPre = function(xhtml)


### PR DESCRIPTION
To create HTML elements with jQuery, the string must start with an HTML element.

## Bug description

I am not sure how my users end up with this HTML saved in the content part, but with the following refinery part content, the editor is breaking: 

```
<p>&#160;</p>\r\n<p>Test</p>
```

The XHTML parser removes the empty p, but leaves the line return and jquery does not accept it to create html elements (`Uncaught Error: Syntax error, unrecognized expression`) : 

![capture d ecran 2018-04-27 a 12 08 55](https://user-images.githubusercontent.com/143380/39372898-cb13f1d8-4a13-11e8-9c3c-b90f22ca9669.png)

Skipping the step like this fixes the issue (but leaves empty tags) ; 

```js
WYMeditor.XhtmlSaxListener.prototype.removeEmptyTags = function(xhtml) { return xhtml; }
```

I suggest adding a step to trim the result.