### PR TITLE
Fix non-English locale issue

### DIFF
--- a/app/assets/javascripts/wymeditor/prototypes.js.erb
+++ b/app/assets/javascripts/wymeditor/prototypes.js.erb
@@ -556,7 +556,7 @@ WYMeditor.editor.prototype.replaceStrings = function(sVal) {
   var wym = this;
   if(!WYMeditor.STRINGS[wym._options.lang]) {
     try {
-      eval($.ajax({url:wym._options.langPath + wym._options.lang + '.js', async:false}).responseText);
+      eval($.ajax({url:"<%= asset_path("wymeditor/lang/#{I18n.locale}") %>", async:false}).responseText);
     } catch(e) {
       if (WYMeditor.console) {
         WYMeditor.console.error("WYMeditor: error while parsing language file.");


### PR DESCRIPTION
Attempt to fix #3

May be a bad idea for reasons unknown to me (the `i18n.locale` might be unsafe to use in this context, for instance), and the hardcoding of the base path `wymeditor/lang/` might be bad, but at least this fix works in my application without needing to hardcode the locale or disabling asset digest URLs.

The way this is done can probably be improved. But since asset_path is basically the only way to get this URL, I think it's an improvement this way.

EDIT: Cleaned up commit history.