### PR TITLE
Require WYMeditor langs folder in wymeditor sprocket manifest

### DIFF
--- a/app/assets/javascripts/refinery/wymeditor.js
+++ b/app/assets/javascripts/refinery/wymeditor.js
@@ -33,6 +33,7 @@
  *= require wymeditor/classes
  *= require wymeditor/validators
  *= require_tree ../wymeditor/browsers
+ *= require_tree ../wymeditor/lang
  *= require wymeditor/init_interface
  *= require refinery/boot_wym
  *= require_self


### PR DESCRIPTION
#57 breaks the inclusion of supported locales

@evenreven ^