### PR TITLE
Remove langs from scripts tags - already included in wymeditor.js

### DIFF
--- a/lib/refinery/wymeditor/engine.rb
+++ b/lib/refinery/wymeditor/engine.rb
@@ -29,7 +29,7 @@ module Refinery
           Refinery::Core.config.register_visual_editor_stylesheet stylesheet
         end
 
-        %W(refinery/wymeditor wymeditor/lang/#{::I18n.locale} wymeditor/skins/refinery/skin).each do |javascript|
+        %w(refinery/wymeditor wymeditor/skins/refinery/skin).each do |javascript|
           Refinery::Core.config.register_visual_editor_javascript javascript
         end
 


### PR DESCRIPTION
Language files are already compiled with `wymeditor.js` as per #59. 

Also fixes error mentioned in #59:

```
ActionView::Template::Error (Asset was not declared to be precompiled in production.
Add `Rails.application.config.assets.precompile += %w( wymeditor/lang/en.js )` to `config/initializers/assets.rb` and restart your server):
```