### PR TITLE
Add `module_function` to `AssetHelper` to fix `asset_exists?`

### DIFF
--- a/app/helpers/asset_helper.rb
+++ b/app/helpers/asset_helper.rb
@@ -1,4 +1,6 @@
 module AssetHelper
+  module_function
+
   def asset_exists?(path)
     if Rails.configuration.assets.compile
       Rails.application.precompiled_assets.include? path


### PR DESCRIPTION
I accidentally merged #53 before tests passed and they failed!

This fixes the broken tests by defining the `asset_exists?` method
in the right scope.