### PR TITLE
Use standard `document.addEventListener`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,9 +10,7 @@ git "https://github.com/refinery/refinerycms", branch: "master" do
   end
 end
 
-# routing-filter needs a newer release than version 0.6.3
 gem 'refinerycms-i18n', github: 'refinery/refinerycms-i18n', branch: 'master'
-gem 'routing-filter', github: 'svenfuchs/routing-filter', branch: 'master'
 
 group :test do
   gem 'launchy'

--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,6 @@ group :assets do
 end
 
 # Load local gems according to Refinery developer preference.
-if File.exist? local_gemfile = File.expand_path('../.gemfile', __FILE__)
+if File.exist?(local_gemfile = File.expand_path('../.gemfile', __FILE__))
   eval File.read(local_gemfile)
 end

--- a/app/assets/javascripts/refinery/boot_wym.js.erb
+++ b/app/assets/javascripts/refinery/boot_wym.js.erb
@@ -242,6 +242,6 @@ WYMeditor.init = function() {
   wymeditor_inputs.wymeditor(wymeditor_boot_options);
 };
 
-$(document).on('ready page:load', function(){
+document.addEventListener("DOMContentLoaded", function(){
   WYMeditor.init();
 });


### PR DESCRIPTION
We are attempting to use `$` to hook into page load, with no guarantees
that this will even work.

Since it was implemented, the web has moved on.. quite a lot.

We can switch to using `document.addEventListener` instead.

Closes #66 